### PR TITLE
Changes leptos_drag_reorder to expose the `Reorderable` component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "any_spawner"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,10 +121,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 
 [[package]]
+name = "cc"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets",
+]
 
 [[package]]
 name = "codee"
@@ -184,6 +222,12 @@ checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crossbeam-utils"
@@ -469,11 +513,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "571a2756b518de368146ba56d4feeba265b0b555d176d49b8debd9ce9b69a6fa"
 dependencies = [
  "futures",
+ "js-sys",
  "once_cell",
  "or_poisoned",
  "pin-project-lite",
  "serde",
  "throw_error",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -632,6 +701,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 
 [[package]]
+name = "inventory"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +800,7 @@ dependencies = [
  "js-sys",
  "leptos",
  "send_wrapper",
+ "thaw_utils",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -767,6 +843,22 @@ dependencies = [
  "server_fn_macro",
  "syn",
  "uuid",
+]
+
+[[package]]
+name = "leptos_meta"
+version = "0.7.0-rc1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15ad116cab8a1073bb6556d65c153d4c951ff06fa84387f723289ee16bb6a7b4"
+dependencies = [
+ "futures",
+ "indexmap",
+ "leptos",
+ "once_cell",
+ "or_poisoned",
+ "send_wrapper",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -872,6 +964,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1307,6 +1408,7 @@ dependencies = [
  "futures",
  "gloo-net",
  "http",
+ "inventory",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -1348,6 +1450,12 @@ dependencies = [
  "server_fn_macro",
  "syn",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"
@@ -1441,6 +1549,19 @@ dependencies = [
  "send_wrapper",
  "slotmap",
  "throw_error",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "thaw_utils"
+version = "0.1.0-beta4"
+dependencies = [
+ "cfg-if",
+ "chrono",
+ "leptos",
+ "leptos_meta",
+ "send_wrapper",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -1713,6 +1834,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,13 @@ include = ["/src", "README.md"]
 js-sys = "0.3.70"
 leptos = "0.7.0-rc1"
 send_wrapper = "0.6.0"
+thaw_utils = { path = "../thaw/thaw_utils/" }
 wasm-bindgen = "0.2.95"
 web-sys = { version = "0.3.70", features = ["DataTransfer", "Document", "DomRect", "Element", "NodeList"] }
+
+
+[features]
+csr = ["leptos/csr", "thaw_utils/csr"]
+ssr = ["leptos/ssr", "thaw_utils/ssr"]
+hydrate = ["leptos/hydrate", "thaw_utils/hydrate"]
+nightly = ["leptos/nightly", "thaw_utils/nightly"]

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -12,6 +12,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "any_spawner"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,10 +121,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 
 [[package]]
+name = "cc"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets",
+]
 
 [[package]]
 name = "codee"
@@ -151,6 +189,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "console_log"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
+dependencies = [
+ "log",
+ "web-sys",
+]
+
+[[package]]
 name = "const_format"
 version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +242,12 @@ checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crossbeam-utils"
@@ -477,6 +541,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +743,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leptos"
 version = "0.7.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +818,7 @@ dependencies = [
  "js-sys",
  "leptos",
  "send_wrapper",
+ "thaw_utils",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -733,8 +827,14 @@ dependencies = [
 name = "leptos_drag_reorder_example"
 version = "0.1.0"
 dependencies = [
+ "console_error_panic_hook",
+ "console_log",
  "leptos",
  "leptos_drag_reorder",
+ "log",
+ "tracing",
+ "tracing-subscriber",
+ "tracing-wasm",
 ]
 
 [[package]]
@@ -883,6 +983,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "oco_ref"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +1022,12 @@ name = "or_poisoned"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c04f5d74368e4d0dfe06c45c8627c81bd7c317d52762d118fb9b3076f6420fd"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -1358,6 +1483,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,6 +1594,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "thaw_utils"
+version = "0.1.0-beta4"
+dependencies = [
+ "cfg-if",
+ "chrono",
+ "leptos",
+ "send_wrapper",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,6 +1623,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -1524,6 +1686,74 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "tracing-wasm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1601,6 +1831,12 @@ checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
@@ -1715,12 +1951,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -4,5 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+console_error_panic_hook = "0.1.7"
+console_log = "1.0.0"
 leptos = { version = "0.7.0-rc1", features = ["csr"] }
 leptos_drag_reorder = { path = ".." }
+log = "0.4"
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"
+tracing-wasm = "0.2.1"

--- a/example/index.html
+++ b/example/index.html
@@ -32,24 +32,6 @@
       background-color: #777;
     }
 
-    .row {
-      display: flex;
-      flex-direction: row;
-      gap: 12px;
-      padding: 16px;
-      margin: 16px;
-      background-color: #222;
-    }
-
-    .column {
-      display: flex;
-      flex: 1;
-      flex-direction: column;
-      gap: 12px;
-      background-color: #333;
-      padding: 16px;
-    }
-
     .panel {
       position: relative;
       padding: 32px 64px;
@@ -57,49 +39,8 @@
       border-radius: 4px;
     }
 
-    .panel::before,
-    .panel::after {
-      position: absolute;
-      background-color: #0ea5e9;
-      border-radius: 8px;
-    }
-
-    .panel.col-item::before,
-    .panel.col-item::after {
-      left: 0;
-      width: 100%;
-      height: 4px;
-    }
-
-    .panel.col-item::before {
-      top: -8px;
-    }
-
-    .panel.col-item::after {
-      bottom: -8px;
-    }
-
-    .panel.row-item::before,
-    .panel.row-item::after {
-      top: 0;
-      height: 100%;
-      width: 4px;
-    }
-
-    .panel.row-item::before {
-      left: -8px;
-    }
-
-    .panel.row-item::after {
-      right: -8px;
-    }
-
-    .panel--above::before {
-      content: '';
-    }
-
-    .panel--below::after {
-      content: '';
+    .background-info {
+        color: #999
     }
   </style>
 </head>

--- a/example/index.html
+++ b/example/index.html
@@ -6,7 +6,7 @@
     body {
       margin: 0;
       font-family: Arial, Helvetica, sans-serif;
-      background-color: #222;
+      background-color: #000;
     }
 
     .root {
@@ -36,6 +36,9 @@
       display: flex;
       flex-direction: row;
       gap: 12px;
+      padding: 16px;
+      margin: 16px;
+      background-color: #222;
     }
 
     .column {
@@ -57,19 +60,38 @@
     .panel::before,
     .panel::after {
       position: absolute;
-      left: 0;
-      width: 100%;
-      height: 4px;
       background-color: #0ea5e9;
       border-radius: 8px;
     }
 
-    .panel::before {
+    .panel.col-item::before,
+    .panel.col-item::after {
+      left: 0;
+      width: 100%;
+      height: 4px;
+    }
+
+    .panel.col-item::before {
       top: -8px;
     }
 
-    .panel::after {
+    .panel.col-item::after {
       bottom: -8px;
+    }
+
+    .panel.row-item::before,
+    .panel.row-item::after {
+      top: 0;
+      height: 100%;
+      width: 4px;
+    }
+
+    .panel.row-item::before {
+      left: -8px;
+    }
+
+    .panel.row-item::after {
+      right: -8px;
     }
 
     .panel--above::before {

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,9 +1,14 @@
-use leptos::{context::Provider, ev, prelude::*};
-use leptos_drag_reorder::{
-    provide_drag_reorder, use_drag_reorder, DragReorderContext, HoverPosition, UseDragReorderReturn,
-};
+use leptos::{ev, prelude::*};
+use leptos_drag_reorder::*;
 
 fn main() {
+    _ = console_log::init_with_level(log::Level::Debug);
+    console_error_panic_hook::set_once();
+    tracing_wasm::set_as_global_default_with_config(
+        tracing_wasm::WASMLayerConfigBuilder::default()
+            .set_max_level(tracing::Level::DEBUG)
+            .build(),
+    );
     mount_to_body(App)
 }
 
@@ -15,180 +20,127 @@ struct Panel {
 
 #[component]
 fn App() -> impl IntoView {
-    let column_panels = RwSignal::new(vec![
+    let panels = RwSignal::new(vec![
         Panel {
             id: 1,
-            title: "Column Panel #1".to_string(),
+            title: "Panel #1".to_string(),
         },
         Panel {
             id: 2,
-            title: "Column Panel #2".to_string(),
+            title: "Panel #2".to_string(),
         },
         Panel {
             id: 3,
-            title: "Column Panel #3".to_string(),
+            title: "Panel #3".to_string(),
         },
     ]);
-    let column_panel_order = [
+    let col_panel_order = [
         // Column 1
         RwSignal::new(vec!["1".into(), "3".into()]),
         // Column 2
         RwSignal::new(vec!["2".into()]),
     ];
-    let (column_refs, col_order_cxt) = provide_drag_reorder(column_panel_order);
 
-    let add_column_panel = {
-        move |_: ev::MouseEvent| {
-            let mut panels = column_panels.write();
-            let next_id = panels.last().map(|item| item.id).unwrap_or(0) + 1;
-            panels.push(Panel {
-                id: next_id,
-                title: format!("Column Panel #{next_id}"),
-            });
-            column_panel_order[0].update(|order| {
-                order.insert(0, next_id.to_string().into());
-            });
-        }
-    };
-
-    let row_panels = RwSignal::new(vec![
-        Panel {
-            id: 1,
-            title: "Row Panel #1".to_string(),
-        },
-        Panel {
-            id: 2,
-            title: "Row Panel #2".to_string(),
-        },
-        Panel {
-            id: 3,
-            title: "Row Panel #3".to_string(),
-        },
-    ]);
     let row_panel_order = [
         // Column 1
-        RwSignal::new(vec!["1".into(), "3".into()]),
+        RwSignal::new(vec!["3".into(), "2".into()]),
         // Column 2
-        RwSignal::new(vec!["2".into()]),
+        RwSignal::new(vec!["1".into()]),
     ];
-    let (row_refs, row_order_cxt) = provide_drag_reorder(row_panel_order);
 
-    let add_row_panel = {
+    let add_panel = {
         move |_: ev::MouseEvent| {
-            let mut panels = row_panels.write();
+            let mut panels = panels.write();
             let next_id = panels.last().map(|item| item.id).unwrap_or(0) + 1;
-            panels.push(Panel {
+            tracing::debug!("Adding panel {}", next_id);
+            let panel = Panel {
                 id: next_id,
-                title: format!("Row Panel #{next_id}"),
+                title: format!("Panel #{}", next_id),
+            };
+            panels.push(panel);
+            col_panel_order[0].update(|order| {
+                order.insert(0, next_id.to_string().into());
             });
             row_panel_order[0].update(|order| {
                 order.insert(0, next_id.to_string().into());
             });
         }
     };
+
+    let col_panel_fn = move |id: Oco<'static, str>| {
+        tracing::debug!("Getting panel");
+        ViewFn::from(move || {
+            panels
+                .read()
+                .iter()
+                .find(|p| p.id.to_string() == id)
+                .map(|p| p.title.clone())
+                .expect("Not to receive an invalid id")
+        })
+    };
+
+    let row_panel_fn = col_panel_fn.clone();
+    let col_order = Signal::derive(move || {
+        col_panel_order
+            .iter()
+            .map(|id_list| {
+                let id_string = id_list
+                    .read()
+                    .iter()
+                    .map(|id: &Oco<'static, str>| id.as_str())
+                    .collect::<Vec<&str>>()
+                    .join(", ");
+                let val = format!(
+                    "{}",
+                    if !id_string.is_empty() {
+                        id_string
+                    } else {
+                        "Empty".to_string()
+                    }
+                );
+                view! { <li>{val}</li> }
+            })
+            .collect_view()
+    });
+    let row_order = Signal::derive(move || {
+        row_panel_order
+            .iter()
+            .map(|id_list| {
+                let id_string = id_list
+                    .read()
+                    .iter()
+                    .map(|id: &Oco<'static, str>| id.as_str())
+                    .collect::<Vec<&str>>()
+                    .join(", ");
+                let val = format!(
+                    "{}",
+                    if !id_string.is_empty() {
+                        id_string
+                    } else {
+                        "Empty".to_string()
+                    }
+                );
+                view! { <li>{val}</li> }
+            })
+            .collect_view()
+    });
     view! {
         <div class="root">
-            <button on:click=add_column_panel>"Add Panel to Columns"</button>
-            <Provider value=col_order_cxt>
-                <div class="row">
-                    {column_panel_order
-                        .into_iter()
-                        .zip(column_refs)
-                        .map(|(ordering, column_ref)| {
-                            let column_items = move || {
-                                ordering
-                                    .read()
-                                    .iter()
-                                    .filter_map(|id| {
-                                        column_panels
-                                            .read()
-                                            .iter()
-                                            .find(|panel| &panel.id.to_string() == id)
-                                            .cloned()
-                                    })
-                                    .collect::<Vec<_>>()
-                            };
-                            view! {
-                                <div node_ref=column_ref class="column">
-                                    <For each=column_items key=|item| item.id let:panel>
-                                        <Panel id=panel.id title=panel.title transpose=false/>
-                                    </For>
-                                </div>
-                            }
-                        })
-                        .collect_view()}
-                </div>
-            </Provider>
-            <button on:click=add_row_panel>"Add Panel to rows"</button>
-            <Provider value=row_order_cxt>
-                {row_panel_order
-                    .into_iter()
-                    .zip(row_refs)
-                    .map(|(ordering, row_ref)| {
-                        let row_items = move || {
-                            ordering
-                                .read()
-                                .iter()
-                                .filter_map(|id| {
-                                    row_panels
-                                        .read()
-                                        .iter()
-                                        .find(|panel| &panel.id.to_string() == id)
-                                        .cloned()
-                                })
-                                .collect::<Vec<_>>()
-                        };
-                        view! {
-                            <div node_ref=row_ref class="row">
-                                <For each=row_items key=|item| item.id let:panel>
-                                    <Panel id=panel.id title=panel.title transpose=true/>
-                                </For>
-                            </div>
-                        }
-                    })
-                    .collect_view()}
-            </Provider>
-
-        </div>
-    }
-}
-
-#[component]
-fn Panel(id: u32, title: String, transpose: bool) -> impl IntoView {
-    let UseDragReorderReturn {
-        node_ref,
-        draggable,
-        set_draggable,
-        hover_position,
-        on_dragstart,
-        on_dragend,
-        ..
-    } = use_drag_reorder(id.to_string(), transpose);
-
-    view! {
-        <div
-            node_ref=node_ref
-            class="panel"
-            class=("row-item", move || transpose)
-
-            class=("col-item", move || !transpose)
-
-            class=(
-                "panel--above",
-                move || matches!(hover_position.get(), Some(HoverPosition::Above)),
-            )
-
-            class=(
-                "panel--below",
-                move || matches!(hover_position.get(), Some(HoverPosition::Below)),
-            )
-
-            draggable=move || draggable.get().then_some("true")
-            on:dragstart=on_dragstart
-            on:dragend=on_dragend
-            on:mousedown=move |_| set_draggable(true)
-        >
-            {title}
+            <button on:click=add_panel>"Add a Panel to both reorderable containers"</button>
+            <h2 class="background-info">"Column-directed reorderable"</h2>
+            <Reorderable panel_order=col_panel_order panel_fn=col_panel_fn panel_class="panel"/>
+            <h3 class="background-info">"Column-directed sort-order"</h3>
+            <ol class="background-info">{col_order}</ol>
+            <hr/>
+            <h2 class="background-info">"Row-directed reorderable"</h2>
+            <Reorderable
+                panel_order=row_panel_order
+                panel_fn=row_panel_fn
+                horizontal=true
+                panel_class="panel"
+            />
+            <h3 class="background-info">"Row-directed sort-order"</h3>
+            <ol class="background-info">{row_order}</ol>
         </div>
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,518 +1,210 @@
-#![doc = include_str!("../README.md")]
+mod reorderable;
 
-use std::collections::HashMap;
+use reorderable::*;
 
-use js_sys::Function;
-use leptos::{ev, html::ElementType, prelude::*, tachys::dom::event_target};
-use send_wrapper::SendWrapper;
-use wasm_bindgen::{prelude::Closure, JsCast};
+use leptos::{context::Provider, prelude::*};
+use std::marker::PhantomData;
+use thaw_utils::{class_list, mount_style};
 
-/// Return value for [`use_drag_reorder`].
-pub struct UseDragReorderReturn<E, SetDraggable, OnDragStart, OnDragEnd>
-where
-    E: ElementType,
-    E::Output: 'static,
-    SetDraggable: Fn(bool) + Copy,
-    OnDragStart: Fn(ev::DragEvent) + Clone,
-    OnDragEnd: Fn(ev::DragEvent) + Clone,
-{
-    /// Node ref which should be assigned to the panel element.
-    pub node_ref: NodeRef<E>,
-    /// Is this panel being dragged.
-    pub is_dragging: Signal<bool>,
-    /// The current position this panel is being hovered over.
-    ///
-    /// This is useful for styling. Typically you would have a line above or below this panel to indicate
-    /// the dragged panel can be dropped.
-    pub hover_position: Signal<Option<HoverPosition>>,
-    /// Is the panel draggable.
-    pub draggable: Signal<bool>,
-    /// Enables/disables the panel to be draggable.
-    pub set_draggable: SetDraggable,
-    /// Callback which should be assigned to the `on:dragstart` event.
-    pub on_dragstart: OnDragStart,
-    /// Callback which should be assigned to the `on:dragend` event.
-    pub on_dragend: OnDragEnd,
+fn default_bookend(_idx: usize) -> ViewFn {
+    ViewFn::from(|| view! {})
 }
 
-/// A hovering panels position either above or below.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum HoverPosition {
-    Above,
-    Below,
-}
-
-/// Registers a panel with drag reordering for a given ID.
-pub fn use_drag_reorder<E>(
-    id: impl Into<Oco<'static, str>>,
-    transpose: bool,
-) -> UseDragReorderReturn<
-    E,
-    impl Fn(bool) + Copy,
-    impl Fn(ev::DragEvent) + Clone,
-    impl Fn(ev::DragEvent) + Clone,
->
-where
-    E: ElementType + 'static,
-    E::Output: JsCast + Into<web_sys::Element> + Clone + 'static,
-{
-    let DragReorderContext {
-        column_refs,
-        panel_order,
-        currently_dragged_panel,
-        hover_info,
-        panels,
-    } = expect_context();
-    let mut id: Oco<'static, str> = id.into();
-    id.upgrade_inplace();
-    let node_ref = NodeRef::<E>::new();
-
-    Effect::new({
-        let id = id.clone();
-        move |_| match node_ref.get() {
-            Some(node_ref) => {
-                panels
-                    .write()
-                    .insert(id.clone(), SendWrapper::new(node_ref.into()));
-            }
-            None => {
-                panels.write().remove(&id);
-            }
-        }
-    });
-
-    on_cleanup({
-        let id = id.clone();
-        move || {
-            panels.write().remove(&id);
-        }
-    });
-
-    let is_dragging = Signal::derive({
-        let id = id.clone();
-        move || currently_dragged_panel.read().as_deref() == Some(id.as_str())
-    });
-    let hover_position = Signal::derive({
-        let id = id.clone();
-        let panel_order = panel_order.clone();
-        move || match &*hover_info.read() {
-            Some(HoverInfo {
-                panel: Some(panel), ..
-            }) => {
-                let currently_dragged_panel = currently_dragged_panel.read();
-                let Some(currently_dragged_panel) = &*currently_dragged_panel else {
-                    return None;
-                };
-
-                let hovering_this_panel = panel.id == id.as_str();
-                let is_currently_dragged_panel = currently_dragged_panel == id.as_str();
-
-                let currently_dragged_panel_index =
-                    panel_order
-                        .iter()
-                        .enumerate()
-                        .find_map(|(column_index, column)| {
-                            column
-                                .read()
-                                .iter()
-                                .position(|panel_id| panel_id == currently_dragged_panel)
-                                .map(|pos| (column_index, pos))
-                        });
-                let hovering_neighbour_panel = match (currently_dragged_panel_index, panel.position)
-                {
-                    (Some((column_index, panel_index)), HoverPosition::Above) => panel_order
-                        .get(column_index)
-                        .and_then(|column| {
-                            column
-                                .read()
-                                .get(panel_index + 1)
-                                .map(|below_id| below_id.as_str() == id)
-                        })
-                        .unwrap_or(false),
-                    (Some((column_index, panel_index)), HoverPosition::Below)
-                        if panel_index > 0 =>
-                    {
-                        panel_order
-                            .get(column_index)
-                            .and_then(|column| {
-                                column
-                                    .read()
-                                    .get(panel_index - 1)
-                                    .map(|below_id| below_id.as_str() == id)
-                            })
-                            .unwrap_or(false)
-                    }
-                    _ => false,
-                };
-                if hovering_this_panel && !is_currently_dragged_panel && !hovering_neighbour_panel {
-                    Some(panel.position)
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        }
-    });
-
-    let draggable = RwSignal::new(false);
-    let set_draggable = move |can_drag: bool| {
-        draggable.set(can_drag);
-    };
-
-    let on_dragover_cb: RwSignal<Option<Function>, LocalStorage> = RwSignal::new_local(None);
-
-    let on_drag_start = {
-        let id = id.clone();
-        move |ev: ev::DragEvent| {
-            currently_dragged_panel.set(Some(id.clone()));
-
-            let dragged_el = event_target::<web_sys::HtmlElement>(&ev);
-            let mouse_x = ev.client_x() as f64;
-            let mouse_y = ev.client_y() as f64;
-            let rect = dragged_el.get_bounding_client_rect();
-
-            // Calculate the center of the element
-            let center_x = rect.x() + rect.width() / 2.0;
-            let center_y = rect.y() + rect.height() / 2.0;
-
-            // Calculate the offset from the mouse position to the center of the element
-            let offset_x = mouse_x - center_x;
-            let offset_y = mouse_y - center_y;
-
-            // Necessary for firefox to emit drag events
-            if let Some(data_transfer) = ev.data_transfer() {
-                let _ = data_transfer.set_data("text/plain", &id);
-            }
-
-            let column_refs = column_refs.clone();
-            let panel_order = panel_order.clone();
-            let on_dragover: Function = Closure::wrap(Box::new(move |ev: web_sys::DragEvent| {
-                ev.prevent_default();
-
-                let mouse_x = ev.client_x() as f64 - offset_x;
-                let mouse_y = ev.client_y() as f64 - offset_y;
-
-                let (closest_column, _) = column_refs.iter().enumerate().fold(
-                    (None, f64::INFINITY),
-                    |(column, closest_dist), (i, column_ref)| {
-                        let Some(column_ref) = &*column_ref.read_untracked() else {
-                            return (column, closest_dist);
-                        };
-                        let rect = column_ref.get_bounding_client_rect();
-                        let dist = match transpose {
-                            false => {
-                                let center_x = rect.left() + rect.width() / 2.0;
-                                (mouse_x - center_x).abs()
-                            }
-                            true => {
-                                let center_y = rect.top() + rect.height() / 2.0;
-                                (mouse_y - center_y).abs()
-                            }
-                        };
-                        if dist < closest_dist {
-                            (Some((i, column_ref.clone())), dist)
-                        } else {
-                            (column, closest_dist)
-                        }
-                    },
-                );
-
-                if let Some((column_index, _)) = closest_column {
-                    let (closest_panel, _) = panels.read_untracked().iter().fold(
-                        (None, f64::INFINITY),
-                        |(closest_panel, closest_dist), (panel_id, panel_ref)| {
-                            let is_in_column = panel_order
-                                .get(column_index)
-                                .map(|column_panels| {
-                                    column_panels.read_untracked().contains(panel_id)
-                                })
-                                .unwrap_or(false);
-                            if !is_in_column {
-                                return (closest_panel, closest_dist);
-                            }
-
-                            let rect = panel_ref.get_bounding_client_rect();
-                            let (dist, center) = match transpose {
-                                false => {
-                                    let center_y = rect.top() + rect.height() / 2.0;
-                                    ((mouse_y - center_y).abs(), center_y)
-                                }
-                                true => {
-                                    let center_x = rect.left() + rect.width() / 2.0;
-                                    ((mouse_x - center_x).abs(), center_x)
-                                }
-                            };
-                            if dist < closest_dist {
-                                (Some((panel_id.clone(), panel_ref.clone(), center)), dist)
-                            } else {
-                                (closest_panel, closest_dist)
-                            }
-                        },
-                    );
-
-                    let new_hover_info = if let Some((panel_id, _, center)) = closest_panel {
-                        if !transpose && mouse_y < center || transpose && mouse_x < center {
-                            Some(HoverInfo {
-                                column_index,
-                                panel: Some(HoveredPanel {
-                                    id: panel_id,
-                                    position: HoverPosition::Above,
-                                }),
-                            })
-                        } else {
-                            Some(HoverInfo {
-                                column_index,
-                                panel: Some(HoveredPanel {
-                                    id: panel_id,
-                                    position: HoverPosition::Below,
-                                }),
-                            })
-                        }
-                    } else {
-                        Some(HoverInfo {
-                            column_index,
-                            panel: None,
-                        })
-                    };
-
-                    hover_info.maybe_update(move |hovered| {
-                        if hovered != &new_hover_info {
-                            *hovered = new_hover_info;
-                            true
-                        } else {
-                            false
-                        }
-                    });
-                }
-            }) as Box<dyn FnMut(_)>)
-            .into_js_value()
-            .dyn_into()
-            .unwrap();
-
-            document()
-                .add_event_listener_with_callback_and_bool("dragover", &on_dragover, false)
-                .unwrap();
-
-            on_dragover_cb.set(Some(on_dragover));
-        }
-    };
-
-    let on_drag_end = {
-        let id = id.clone();
-        move |_ev: ev::DragEvent| {
-            if let Some(on_dragover) = on_dragover_cb.write().take() {
-                document()
-                    .remove_event_listener_with_callback("dragover", &on_dragover)
-                    .unwrap();
-            }
-
-            let id = id.clone();
-            request_animation_frame(move || {
-                let mut current = currently_dragged_panel.write();
-                if current.as_deref() == Some(&id) {
-                    hover_info.set(None);
-                    draggable.set(false);
-                    *current = None;
-                }
-            });
-        }
-    };
-
-    UseDragReorderReturn {
-        node_ref,
-        is_dragging,
-        hover_position,
-        draggable: draggable.into(),
-        set_draggable,
-        on_dragstart: on_drag_start,
-        on_dragend: on_drag_end,
-    }
-}
-
-#[derive(Clone)]
-pub struct DragReorderContext {
-    column_refs: Vec<Signal<Option<SendWrapper<web_sys::Element>>>>,
-    panel_order: Vec<RwSignal<Vec<Oco<'static, str>>>>,
-    currently_dragged_panel: RwSignal<Option<Oco<'static, str>>>,
-    hover_info: RwSignal<Option<HoverInfo>>,
-    panels: RwSignal<HashMap<Oco<'static, str>, SendWrapper<web_sys::Element>>>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct HoverInfo {
-    column_index: usize,
-    panel: Option<HoveredPanel>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct HoveredPanel {
-    id: Oco<'static, str>,
-    position: HoverPosition,
-}
-
-pub fn provide_drag_reorder<const COLUMNS: usize, E>(
+#[component]
+pub fn Reorderable<const COLUMNS: usize, PanelFn>(
     panel_order: [RwSignal<Vec<Oco<'static, str>>>; COLUMNS],
-) -> ([NodeRef<E>; COLUMNS], DragReorderContext)
+    panel_fn: PanelFn,
+    #[prop(optional)] horizontal: bool,
+    #[prop(optional, into)] container_class: MaybeProp<String>,
+    #[prop(optional, into)] panel_class: MaybeProp<String>,
+) -> impl IntoView
 where
-    E: ElementType + 'static,
-    E::Output: JsCast + Into<web_sys::Element> + Clone + 'static,
+    PanelFn: Fn(Oco<'static, str>) -> ViewFn + Send + 'static + Clone,
 {
-    let column_refs: Vec<NodeRef<E>> = panel_order
-        .iter()
-        .map(|_| NodeRef::new())
-        .collect::<Vec<_>>();
-    let ctx = DragReorderContext {
-        panel_order: panel_order.to_vec(),
-        column_refs: column_refs
-            .clone()
-            .into_iter()
-            .map(|column_ref| {
-                Signal::derive(move || {
-                    column_ref
-                        .get()
-                        .map(|column_ref| SendWrapper::new(column_ref.into()))
-                })
-            })
-            .collect(),
-        currently_dragged_panel: RwSignal::new(None),
-        hover_info: RwSignal::new(None),
-        panels: RwSignal::new(HashMap::new()),
-    };
-
-    Effect::new({
-        move |mut last_on_dragend: Option<Function>| {
-            if let Some(last_on_dragend) = last_on_dragend.take() {
-                let _ = document().remove_event_listener_with_callback("dragend", &last_on_dragend);
-            }
-
-            let on_dragend: Function = Closure::wrap(Box::new(move |_ev: web_sys::MouseEvent| {
-                if let Some((currently_dragged_panel, hover_info)) = ctx
-                    .currently_dragged_panel
-                    .read_untracked()
-                    .as_ref()
-                    .zip(ctx.hover_info.get_untracked())
-                {
-                    reorder_panel_order(&panel_order, &currently_dragged_panel, hover_info);
-                }
-            }) as Box<dyn FnMut(_)>)
-            .into_js_value()
-            .dyn_into()
-            .unwrap();
-
-            document()
-                .add_event_listener_with_callback("dragend", &on_dragend)
-                .unwrap();
-
-            on_cleanup({
-                let on_dragend = SendWrapper::new(on_dragend.clone());
-                move || {
-                    let _ = document()
-                        .remove_event_listener_with_callback("dragend", &on_dragend.take());
-                }
-            });
-
-            on_dragend
-        }
-    });
-
-    (
-        column_refs
-            .try_into()
-            .ok()
-            .expect("vec should be same size as array"),
-        ctx,
-    )
+    view! {
+        <CustomReorderable
+            panel_order
+            panel_fn
+            header_fn=default_bookend
+            footer_fn=default_bookend
+            horizontal
+            container_class
+            panel_class
+        />
+    }
 }
 
-fn reorder_panel_order(
-    panel_order: &[RwSignal<Vec<Oco<'static, str>>>],
-    currently_dragged_panel: &str,
-    hover_info: HoverInfo,
-) {
-    // Extract hover information
-    let HoverInfo {
-        column_index: to_col_index,
-        panel: maybe_hovered_panel,
-    } = hover_info;
-
-    // Initialize variables to store the original position of the dragged panel
-    let mut from_col_index = None;
-    let mut from_row_index = None;
-
-    // Find the column and row index of the currently dragged panel
-    for (col_idx, col_signal) in panel_order.iter().enumerate() {
-        let col_panels = col_signal.get_untracked();
-        if let Some(row_idx) = col_panels
+#[component]
+pub fn CustomReorderable<const COLUMNS: usize, PanelFn, HeaderFn, FooterFn>(
+    panel_order: [RwSignal<Vec<Oco<'static, str>>>; COLUMNS],
+    panel_fn: PanelFn,
+    header_fn: HeaderFn,
+    footer_fn: FooterFn,
+    #[prop(optional)] horizontal: bool,
+    #[prop(optional, into)] container_class: MaybeProp<String>,
+    #[prop(optional, into)] panel_class: MaybeProp<String>,
+) -> impl IntoView
+where
+    PanelFn: Fn(Oco<'static, str>) -> ViewFn + Send + 'static + Clone,
+    HeaderFn: Fn(usize) -> ViewFn + Send + 'static + Clone,
+    FooterFn: Fn(usize) -> ViewFn + Send + 'static + Clone,
+{
+    mount_style("reorderable", include_str!("./reorderable.css"));
+    let ctx = ReorderContext::new(panel_order.clone(), horizontal);
+    let panel_getter = StoredValue::new_local(panel_fn);
+    let header_getter = StoredValue::new_local(header_fn);
+    let footer_getter = StoredValue::new_local(footer_fn);
+    // dummy_array is a compile-time way to let ColumnnWrapper know COLUMNS.
+    let dummy_array: [PhantomData<bool>; COLUMNS] = ctx.column_node_refs.map(|_| PhantomData);
+    let column_getter = move || {
+        panel_order
             .iter()
-            .position(|panel_id| panel_id.as_str() == currently_dragged_panel)
-        {
-            from_col_index = Some(col_idx);
-            from_row_index = Some(row_idx);
-            break;
-        }
+            .enumerate()
+            .map(|(idx, _)| (idx, dummy_array.clone()))
+            .collect::<Vec<(usize, [PhantomData<bool>; COLUMNS])>>()
+    };
+    view! {
+        <div class="reorderable" class=("horizontal", horizontal)>
+            <Provider value=ctx>
+                <For each=column_getter key=|(idx, _dummy)| idx.to_string() let:value>
+                    <PanelContainer
+                        index=value.0
+                        dummy=value.1
+                        panel_getter=panel_getter.clone()
+                        class=container_class.clone()
+                        header_getter=header_getter.clone()
+                        footer_getter=footer_getter.clone()
+                        panel_class=panel_class.clone()
+                    />
+                </For>
+            </Provider>
+        </div>
     }
+}
 
-    // Proceed only if the dragged panel was found
-    if let (Some(from_col_index), Some(from_row_index)) = (from_col_index, from_row_index) {
-        // Get the target column's panels
-        let to_col_signal = &panel_order[to_col_index];
-        let mut to_col_panels = to_col_signal.get_untracked();
+#[component]
+fn PanelContainer<const COLUMNS: usize, PanelFn, HeaderFn, FooterFn>(
+    index: usize,
+    dummy: [PhantomData<bool>; COLUMNS],
+    panel_getter: StoredValue<PanelFn, LocalStorage>,
+    header_getter: StoredValue<HeaderFn, LocalStorage>,
+    footer_getter: StoredValue<FooterFn, LocalStorage>,
+    #[prop(optional, into)] class: MaybeProp<String>,
+    #[prop(optional, into)] panel_class: MaybeProp<String>,
+) -> impl IntoView
+where
+    PanelFn: Fn(Oco<'static, str>) -> ViewFn + Send + 'static + Clone,
+    HeaderFn: Fn(usize) -> ViewFn + Send + 'static + Clone,
+    FooterFn: Fn(usize) -> ViewFn + Send + 'static + Clone,
+{
+    let ctx = expect_context::<ReorderContext<COLUMNS>>();
+    let node_ref = ctx.column_node_refs[index];
+    let panel_order = ctx.panel_order[index];
+    let panel_ids = move || {
+        panel_order
+            .read()
+            .iter()
+            .cloned()
+            .collect::<Vec<Oco<'static, str>>>()
+    };
+    view! {
+        <div
+            node_ref=node_ref
+            class=class_list!["reorderable-container", class]
+            class=("horizontal", ctx.horizontal)
+        >
+            <ContainerHeader index horizontal=ctx.horizontal _dummy=dummy.clone()>
+                {header_getter.with_value(|header_fn| header_fn(index).run())}
+            </ContainerHeader>
+            <For each=panel_ids key=|item| item.clone() let:id>
+                <PanelWrapper id=id.clone() _dummy=dummy.clone() class=panel_class.clone()>
+                    {panel_getter.with_value(|panel_fn| panel_fn(id.clone()).run())}
+                </PanelWrapper>
+            </For>
+            <ContainerFooter horizontal=ctx.horizontal>
+                {footer_getter.with_value(|footer_fn| footer_fn(index).run())}
+            </ContainerFooter>
+        </div>
+    }
+}
 
-        // Determine the insertion index
-        let insert_row_index = match maybe_hovered_panel {
-            Some(HoveredPanel {
-                id: hovered_panel_id,
-                position: hover_position,
-            }) => {
-                // Find the index of the hovered panel in the target column
-                if let Some(hovered_row_index) = to_col_panels
-                    .iter()
-                    .position(|panel_id| panel_id.as_str() == hovered_panel_id)
-                {
-                    // Determine the insertion index based on the hover position
-                    let mut idx = match hover_position {
-                        HoverPosition::Above => hovered_row_index,
-                        HoverPosition::Below => hovered_row_index + 1,
-                    };
+#[component]
+fn ContainerHeader<const COLUMNS: usize>(
+    index: usize,
+    horizontal: bool,
+    _dummy: [PhantomData<bool>; COLUMNS],
+    children: ChildrenFn,
+) -> impl IntoView {
+    let ctx = expect_context::<ReorderContext<COLUMNS>>();
+    let (node_ref, hover_position) = ctx.generate_header(index);
+    view! {
+        <div
+            node_ref=node_ref
+            class="header item"
+            class=("row-item", move || horizontal)
+            class=("col-item", move || !horizontal)
+            class=("item--after", move || hover_position.get().is_some())
+        >
+            {children()}
+        </div>
+    }
+}
 
-                    // Adjust the insertion index if moving within the same column
-                    if from_col_index == to_col_index && from_row_index < idx {
-                        idx -= 1;
-                    }
-                    idx
-                } else {
-                    // If hovered panel is not found, insert at the end
-                    to_col_panels.len()
-                }
-            }
-            None => {
-                // No hovered panel; insert at the end of the column
-                to_col_panels.len()
-            }
-        };
+#[component]
+fn ContainerFooter(horizontal: bool, children: ChildrenFn) -> impl IntoView {
+    view! {
+        <div
+            class="footer item"
+            class=("row-item", move || horizontal)
+            class=("col-item", move || !horizontal)
+        >
+            {children()}
+        </div>
+    }
+}
 
-        // Remove the dragged panel from its original position
-        let from_col_signal = &panel_order[from_col_index];
-        let mut from_col_panels = from_col_signal.get_untracked();
-        from_col_panels.remove(from_row_index);
+#[component]
+fn PanelWrapper<const COLUMNS: usize>(
+    id: Oco<'static, str>,
+    _dummy: [PhantomData<bool>; COLUMNS],
+    #[prop(optional, into)] class: MaybeProp<String>,
+    children: ChildrenFn,
+) -> impl IntoView {
+    let ctx = expect_context::<ReorderContext<COLUMNS>>();
+    let horizontal = ctx.horizontal;
+    let PanelReorderEvents {
+        node_ref,
+        draggable,
+        set_draggable,
+        hover_position,
+        on_dragstart,
+        is_dragging,
+        on_dragend,
+        ..
+    } = ctx.generate_panel(id);
+    view! {
+        <div
+            node_ref=node_ref
+            class=class_list!["item", class]
+            class=("row-item", move || horizontal)
+            class=("col-item", move || !horizontal)
+            class=("dragging", move || is_dragging.get())
+            class=(
+                "item--before",
+                move || matches!(hover_position.get(), Some(HoverPosition::Before)),
+            )
 
-        if from_col_index == to_col_index {
-            // Insert the panel into the same column at the new position
-            from_col_panels.insert(
-                insert_row_index,
-                Oco::from(currently_dragged_panel.to_string()),
-            );
-            from_col_signal.set(from_col_panels);
-        } else {
-            // Write back the modified original column
-            from_col_signal.set(from_col_panels);
+            class=(
+                "item--after",
+                move || matches!(hover_position.get(), Some(HoverPosition::After)),
+            )
 
-            // Insert the panel into the new column
-            to_col_panels.insert(
-                insert_row_index,
-                Oco::from(currently_dragged_panel.to_string()),
-            );
-            to_col_signal.set(to_col_panels);
-        }
+            draggable=move || draggable.get().then_some("true")
+            on:dragstart=on_dragstart
+            on:dragend=on_dragend
+            on:mousedown=move |_| set_draggable(true)
+        >
+            {children()}
+        </div>
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub enum HoverPosition {
 /// Registers a panel with drag reordering for a given ID.
 pub fn use_drag_reorder<E>(
     id: impl Into<Oco<'static, str>>,
+    transpose: bool,
 ) -> UseDragReorderReturn<
     E,
     impl Fn(bool) + Copy,
@@ -198,8 +199,16 @@ where
                             return (column, closest_dist);
                         };
                         let rect = column_ref.get_bounding_client_rect();
-                        let center_x = rect.left() + rect.width() / 2.0;
-                        let dist = (mouse_x - center_x).abs();
+                        let dist = match transpose {
+                            false => {
+                                let center_x = rect.left() + rect.width() / 2.0;
+                                (mouse_x - center_x).abs()
+                            }
+                            true => {
+                                let center_y = rect.top() + rect.height() / 2.0;
+                                (mouse_y - center_y).abs()
+                            }
+                        };
                         if dist < closest_dist {
                             (Some((i, column_ref.clone())), dist)
                         } else {
@@ -223,18 +232,26 @@ where
                             }
 
                             let rect = panel_ref.get_bounding_client_rect();
-                            let center_y = rect.top() + rect.height() / 2.0;
-                            let dist = (mouse_y - center_y).abs();
+                            let (dist, center) = match transpose {
+                                false => {
+                                    let center_y = rect.top() + rect.height() / 2.0;
+                                    ((mouse_y - center_y).abs(), center_y)
+                                }
+                                true => {
+                                    let center_x = rect.left() + rect.width() / 2.0;
+                                    ((mouse_x - center_x).abs(), center_x)
+                                }
+                            };
                             if dist < closest_dist {
-                                (Some((panel_id.clone(), panel_ref.clone(), center_y)), dist)
+                                (Some((panel_id.clone(), panel_ref.clone(), center)), dist)
                             } else {
                                 (closest_panel, closest_dist)
                             }
                         },
                     );
 
-                    let new_hover_info = if let Some((panel_id, _, center_y)) = closest_panel {
-                        if mouse_y < center_y {
+                    let new_hover_info = if let Some((panel_id, _, center)) = closest_panel {
+                        if !transpose && mouse_y < center || transpose && mouse_x < center {
                             Some(HoverInfo {
                                 column_index,
                                 panel: Some(HoveredPanel {
@@ -313,7 +330,7 @@ where
 }
 
 #[derive(Clone)]
-struct DragReorderContext {
+pub struct DragReorderContext {
     column_refs: Vec<Signal<Option<SendWrapper<web_sys::Element>>>>,
     panel_order: Vec<RwSignal<Vec<Oco<'static, str>>>>,
     currently_dragged_panel: RwSignal<Option<Oco<'static, str>>>,
@@ -335,7 +352,7 @@ struct HoveredPanel {
 
 pub fn provide_drag_reorder<const COLUMNS: usize, E>(
     panel_order: [RwSignal<Vec<Oco<'static, str>>>; COLUMNS],
-) -> [NodeRef<E>; COLUMNS]
+) -> ([NodeRef<E>; COLUMNS], DragReorderContext)
 where
     E: ElementType + 'static,
     E::Output: JsCast + Into<web_sys::Element> + Clone + 'static,
@@ -398,12 +415,13 @@ where
         }
     });
 
-    provide_context(ctx);
-
-    column_refs
-        .try_into()
-        .ok()
-        .expect("vec should be same size as array")
+    (
+        column_refs
+            .try_into()
+            .ok()
+            .expect("vec should be same size as array"),
+        ctx,
+    )
 }
 
 fn reorder_panel_order(

--- a/src/reorderable.css
+++ b/src/reorderable.css
@@ -1,0 +1,80 @@
+div.reorderable {
+    display: flex;
+    flex-direction: row;
+    flex: 1;
+    gap: 12px;
+    padding: 16px;
+}
+
+div.reorderable.horizontal {
+    flex-direction: column;
+}
+
+div.reorderable-container {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    gap: 12px;
+    padding: 16px;
+}
+
+div.reorderable-container.horizontal {
+    flex-direction: row;
+}
+
+div.reorderable-container > div.item {
+  position: relative;
+}
+
+div.reorderable-container > div.item.col-item {
+    min-width: 1em;
+}
+
+div.reorderable-container > div.item.row-item {
+    min-height: 1em;
+}
+
+div.reorderable-container > div.dragging {
+    opacity: 70%;
+}
+
+div.reorderable-container > div.col-item::before,
+div.reorderable-container > div.col-item::after {
+  left: 0;
+  width: 100%;
+  height: 4px;
+  position: absolute;
+  background-color: #0ea5e9;
+  border-radius: 8px;
+}
+
+div.reorderable-container > div.col-item::before {
+  top: -8px;
+}
+
+div.reorderable-container > div.col-item::after {
+  bottom: -8px;
+}
+
+div.reorderable-container > div.row-item::before,
+div.reorderable-container > div.row-item::after {
+  top: 0;
+  height: 100%;
+  width: 4px;
+  position: absolute;
+  background-color: #0ea5e9;
+  border-radius: 8px;
+}
+
+div.reorderable-container > div.row-item::before {
+  left: -8px;
+}
+
+div.reorderable-container > div.row-item::after {
+  right: -8px;
+}
+
+div.reorderable-container > div.item--before::before,
+div.reorderable-container > div.item--after::after {
+  content: '';
+}

--- a/src/reorderable.rs
+++ b/src/reorderable.rs
@@ -1,0 +1,543 @@
+use std::collections::HashMap;
+
+use leptos::{
+    ev,
+    html::Div,
+    prelude::*,
+    tachys::dom::event_target,
+};
+use send_wrapper::SendWrapper;
+use wasm_bindgen::{prelude::Closure, JsCast};
+use web_sys::js_sys::Function;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HoverInfo {
+    column_index: usize,
+    panel: Option<HoveredPanel>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HoveredPanel {
+    id: Oco<'static, str>,
+    position: HoverPosition,
+}
+
+#[derive(Clone)]
+pub struct ReorderContext<const COLUMNS: usize> {
+    pub column_node_refs: [NodeRef<Div>; COLUMNS],
+    pub column_refs: [Signal<Option<SendWrapper<web_sys::Element>>>; COLUMNS],
+    pub panel_order: [RwSignal<Vec<Oco<'static, str>>>; COLUMNS],
+    pub currently_dragged_panel: RwSignal<Option<Oco<'static, str>>>,
+    pub hover_info: RwSignal<Option<HoverInfo>>,
+    pub panels: RwSignal<HashMap<Oco<'static, str>, SendWrapper<web_sys::Element>>>,
+    pub horizontal: bool,
+    initialized: RwSignal<bool>,
+}
+
+impl<const COLUMNS: usize> ReorderContext<COLUMNS> {
+    pub fn new(
+        panel_array: [RwSignal<Vec<Oco<'static, str>>>; COLUMNS],
+        horizontal: bool,
+    ) -> ReorderContext<COLUMNS> {
+        let column_node_refs: [NodeRef<Div>; COLUMNS] = panel_array.map(|_| NodeRef::new());
+        let column_refs = column_node_refs.map(|column_ref| {
+            Signal::derive(move || {
+                column_ref
+                    .get()
+                    .map(|column_ref| SendWrapper::new(column_ref.into()))
+            })
+        });
+        for container in panel_array.iter() {
+            for id in container.write_untracked().iter_mut() {
+                id.upgrade_inplace();
+            }
+        }
+        let ctx = ReorderContext {
+            column_node_refs,
+            column_refs,
+            horizontal,
+            panel_order: panel_array.clone(),
+            currently_dragged_panel: RwSignal::new(None),
+            hover_info: RwSignal::new(None),
+            panels: RwSignal::new(HashMap::new()),
+            initialized: RwSignal::new(false),
+        };
+        ctx
+    }
+
+    pub fn initialize(&self) {
+        Effect::new(move |mut last_on_dragend: Option<Function>| {
+            if let Some(last_on_dragend) = last_on_dragend.take() {
+                let _ = document().remove_event_listener_with_callback("dragend", &last_on_dragend);
+            }
+
+            let closure_ctx = expect_context::<ReorderContext<COLUMNS>>();
+            let on_dragend: Function = Closure::wrap(Box::new(move |_ev: web_sys::MouseEvent| {
+                if let Some((currently_dragged_panel, hover_info)) = closure_ctx
+                    .currently_dragged_panel
+                    .read_untracked()
+                    .as_ref()
+                    .zip(closure_ctx.hover_info.get_untracked())
+                {
+                    closure_ctx.reorder_panels(&currently_dragged_panel, hover_info);
+                }
+            }) as Box<dyn FnMut(_)>)
+            .into_js_value()
+            .dyn_into()
+            .unwrap();
+
+            document()
+                .add_event_listener_with_callback("dragend", &on_dragend)
+                .unwrap();
+
+            on_cleanup({
+                let on_dragend = SendWrapper::new(on_dragend.clone());
+                move || {
+                    let _ = document()
+                        .remove_event_listener_with_callback("dragend", &on_dragend.take());
+                }
+            });
+
+            on_dragend
+        });
+        self.initialized.set(true);
+    }
+
+    fn reorder_panels(&self, currently_dragged_panel: &str, hover_info: HoverInfo) {
+        // Extract hover information
+        let HoverInfo {
+            column_index: to_col_index,
+            panel: maybe_hovered_panel,
+        } = hover_info;
+        // Initialize variables to store the original position of the dragged panel
+        let mut from_col_index = None;
+        let mut from_row_index = None;
+
+        // Find the column and row index of the currently dragged panel
+        for (col_idx, col_signal) in self.panel_order.iter().enumerate() {
+            let col_panels = col_signal.get_untracked();
+            if let Some(row_idx) = col_panels
+                .iter()
+                .position(|panel_id| panel_id.as_str() == currently_dragged_panel)
+            {
+                from_col_index = Some(col_idx);
+                from_row_index = Some(row_idx);
+                break;
+            }
+        }
+        // Proceed only if the dragged panel was found
+        if let (Some(from_col_index), Some(from_row_index)) = (from_col_index, from_row_index) {
+            // Get the target column's panels
+            let to_col_signal = self.panel_order[to_col_index];
+            let mut to_col_panels = to_col_signal.get_untracked();
+
+            // Determine the insertion index
+            let insert_row_index = match maybe_hovered_panel {
+                Some(HoveredPanel {
+                    id: hovered_panel_id,
+                    position: hover_position,
+                }) => {
+                    // Find the index of the hovered panel in the target column
+                    if let Some(hovered_row_index) = to_col_panels
+                        .iter()
+                        .position(|panel_id| panel_id.as_str() == hovered_panel_id)
+                    {
+                        // Determine the insertion index based on the hover position
+                        let mut idx = match hover_position {
+                            HoverPosition::Before => hovered_row_index,
+                            HoverPosition::After => hovered_row_index + 1,
+                        };
+
+                        // Adjust the insertion index if moving within the same column
+                        if from_col_index == to_col_index && from_row_index < idx {
+                            idx -= 1;
+                        }
+                        idx
+                    } else {
+                        // If hovered panel is not found, insert at the end
+                        to_col_panels.len()
+                    }
+                }
+                None => {
+                    // No hovered panel; insert at the end of the column
+                    to_col_panels.len()
+                }
+            };
+
+            // Remove the dragged panel from its original position
+            let from_col_signal = self.panel_order[from_col_index];
+            let mut from_col_panels = from_col_signal.get_untracked();
+            from_col_panels.remove(from_row_index);
+
+            if from_col_index == to_col_index {
+                // Insert the panel into the same column at the new position
+                from_col_panels.insert(
+                    insert_row_index,
+                    Oco::from(currently_dragged_panel.to_string()),
+                );
+                from_col_signal.set(from_col_panels);
+            } else {
+                // Write back the modified original column
+                from_col_signal.set(from_col_panels);
+
+                // Insert the panel into the new column
+                to_col_panels.insert(
+                    insert_row_index,
+                    Oco::from(currently_dragged_panel.to_string()),
+                );
+                to_col_signal.set(to_col_panels);
+            }
+        }
+    }
+
+    /// Registers a panel with drag reordering for a given ID.
+    pub fn generate_panel(
+        &self,
+        id: impl Into<Oco<'static, str>>,
+    ) -> PanelReorderEvents<
+        impl Fn(bool) + Copy,
+        impl Fn(ev::DragEvent) + Clone,
+        impl Fn(ev::DragEvent) + Clone,
+    > {
+        if !self.initialized.get_untracked() {
+            self.initialize();
+        }
+        let mut id: Oco<'static, str> = id.into();
+        id.upgrade_inplace();
+        let node_ref = NodeRef::<Div>::new();
+
+        let panels = self.panels.clone();
+        Effect::new({
+            let id = id.clone();
+            move |_| match node_ref.get() {
+                Some(node_ref) => {
+                    panels
+                        .write()
+                        .insert(id.clone(), SendWrapper::new(node_ref.into()));
+                }
+                None => {
+                    panels.write().remove(&id);
+                }
+            }
+        });
+
+        let panels = self.panels.clone();
+        on_cleanup({
+            let id = id.clone();
+            move || {
+                panels.write().remove(&id);
+            }
+        });
+
+        let is_dragging = Signal::derive({
+            let id = id.clone();
+            let currently_dragged_panel = self.currently_dragged_panel.clone();
+            move || currently_dragged_panel.read().as_deref() == Some(id.as_str())
+        });
+        let hover_position = Signal::derive({
+            let id = id.clone();
+            let currently_dragged_panel = self.currently_dragged_panel.clone();
+            let panel_order = self.panel_order.clone();
+            let hover_info = self.hover_info.clone();
+            move || match &*hover_info.read() {
+                Some(HoverInfo {
+                    panel: Some(panel), ..
+                }) => {
+                    let currently_dragged_panel = currently_dragged_panel.read();
+                    let Some(currently_dragged_panel) = &*currently_dragged_panel else {
+                        return None;
+                    };
+
+                    let hovering_this_panel = panel.id == id.as_str();
+                    let is_currently_dragged_panel = currently_dragged_panel == id.as_str();
+
+                    let currently_dragged_panel_index =
+                        panel_order
+                            .iter()
+                            .enumerate()
+                            .find_map(|(column_index, column)| {
+                                column
+                                    .read()
+                                    .iter()
+                                    .position(|panel_id| panel_id == currently_dragged_panel)
+                                    .map(|pos| (column_index, pos))
+                            });
+                    let hovering_neighbour_panel =
+                        match (currently_dragged_panel_index, panel.position) {
+                            (Some((column_index, panel_index)), HoverPosition::Before) => {
+                                panel_order
+                                    .get(column_index)
+                                    .and_then(|column| {
+                                        column
+                                            .read()
+                                            .get(panel_index + 1)
+                                            .map(|below_id| below_id.as_str() == id)
+                                    })
+                                    .unwrap_or(false)
+                            }
+                            (Some((column_index, panel_index)), HoverPosition::After)
+                                if panel_index > 0 =>
+                            {
+                                panel_order
+                                    .get(column_index)
+                                    .and_then(|column| {
+                                        column
+                                            .read()
+                                            .get(panel_index - 1)
+                                            .map(|below_id| below_id.as_str() == id)
+                                    })
+                                    .unwrap_or(false)
+                            }
+                            _ => false,
+                        };
+                    if hovering_this_panel
+                        && !is_currently_dragged_panel
+                        && !hovering_neighbour_panel
+                    {
+                        Some(panel.position)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            }
+        });
+
+        let draggable = RwSignal::new(false);
+        let set_draggable = move |can_drag: bool| {
+            draggable.set(can_drag);
+        };
+
+        let on_dragover_cb: RwSignal<Option<Function>, LocalStorage> = RwSignal::new_local(None);
+
+        let on_drag_start = {
+            let id = id.clone();
+            let currently_dragged_panel = self.currently_dragged_panel.clone();
+            let column_refs = self.column_refs.clone();
+            let panel_order = self.panel_order.clone();
+            let horizontal = self.horizontal;
+            let panels = self.panels.clone();
+            let hover_info = self.hover_info.clone();
+            move |ev: ev::DragEvent| {
+                currently_dragged_panel.set(Some(id.clone()));
+                let dragged_el = event_target::<web_sys::HtmlElement>(&ev);
+                let mouse_x = ev.client_x() as f64;
+                let mouse_y = ev.client_y() as f64;
+                let rect = dragged_el.get_bounding_client_rect();
+                // Calculate the center of the element
+                let center_x = rect.x() + rect.width() / 2.0;
+                let center_y = rect.y() + rect.height() / 2.0;
+                // Calculate the offset from the mouse position to the center of the element
+                let offset_x = mouse_x - center_x;
+                let offset_y = mouse_y - center_y;
+
+                // Necessary for firefox to emit drag events
+                if let Some(data_transfer) = ev.data_transfer() {
+                    let _ = data_transfer.set_data("text/plain", &id);
+                }
+
+                let on_dragover: Function = Closure::wrap(Box::new(move |ev: web_sys::DragEvent| {
+                    ev.prevent_default();
+
+                    let mouse_x = ev.client_x() as f64 - offset_x;
+                    let mouse_y = ev.client_y() as f64 - offset_y;
+
+                    let (closest_column, _) = column_refs.iter().enumerate().fold(
+                        (None, f64::INFINITY),
+                        |(column, closest_dist), (i, column_ref)| {
+                            let Some(column_ref) = &*column_ref.read_untracked() else {
+                                return (column, closest_dist);
+                            };
+                            let rect = column_ref.get_bounding_client_rect();
+                            let dist = match horizontal {
+                                false => {
+                                    let center_x = rect.left() + rect.width() / 2.0;
+                                    (mouse_x - center_x).abs()
+                                }
+                                true => {
+                                    let center_y = rect.top() + rect.height() / 2.0;
+                                    (mouse_y - center_y).abs()
+                                }
+                            };
+                            if dist < closest_dist {
+                                (Some((i, column_ref.clone())), dist)
+                            } else {
+                                (column, closest_dist)
+                            }
+                        },
+                    );
+
+                    if let Some((column_index, _)) = closest_column {
+                        let (closest_panel, _) = panels.read_untracked().iter().fold(
+                            (None, f64::INFINITY),
+                            |(closest_panel, closest_dist), (panel_id, panel_ref)| {
+                                let is_in_column = panel_order
+                                    .get(column_index)
+                                    .map(|column_panels| {
+                                        column_panels.read_untracked().contains(panel_id)
+                                    })
+                                    .unwrap_or(false);
+                                if !is_in_column {
+                                    return (closest_panel, closest_dist);
+                                }
+
+                                let rect = panel_ref.get_bounding_client_rect();
+                                let (dist, center) = match horizontal {
+                                    false => {
+                                        let center_y = rect.top() + rect.height() / 2.0;
+                                        ((mouse_y - center_y).abs(), center_y)
+                                    }
+                                    true => {
+                                        let center_x = rect.left() + rect.width() / 2.0;
+                                        ((mouse_x - center_x).abs(), center_x)
+                                    }
+                                };
+                                if dist < closest_dist {
+                                    (Some((panel_id.clone(), panel_ref.clone(), center)), dist)
+                                } else {
+                                    (closest_panel, closest_dist)
+                                }
+                            },
+                        );
+
+                        let new_hover_info = if let Some((panel_id, _, center)) = closest_panel {
+                            if !horizontal && mouse_y < center || horizontal && mouse_x < center {
+                                Some(HoverInfo {
+                                    column_index,
+                                    panel: Some(HoveredPanel {
+                                        id: panel_id,
+                                        position: HoverPosition::Before,
+                                    }),
+                                })
+                            } else {
+                                Some(HoverInfo {
+                                    column_index,
+                                    panel: Some(HoveredPanel {
+                                        id: panel_id,
+                                        position: HoverPosition::After,
+                                    }),
+                                })
+                            }
+                        } else {
+                            Some(HoverInfo {
+                                column_index,
+                                panel: None,
+                            })
+                        };
+
+                        hover_info.maybe_update(move |hovered| {
+                            if hovered != &new_hover_info {
+                                *hovered = new_hover_info;
+                                true
+                            } else {
+                                false
+                            }
+                        });
+                    }
+                }) as Box<dyn FnMut(_)>)
+                .into_js_value()
+                .dyn_into()
+                .unwrap();
+
+                document()
+                    .add_event_listener_with_callback_and_bool("dragover", &on_dragover, false)
+                    .unwrap();
+
+                on_dragover_cb.set(Some(on_dragover));
+            }
+        };
+
+        let currently_dragged_panel = self.currently_dragged_panel.clone();
+        let hover_info = self.hover_info.clone();
+        let on_drag_end = {
+            let id = id.clone();
+            move |_ev: ev::DragEvent| {
+                if let Some(on_dragover) = on_dragover_cb.write().take() {
+                    document()
+                        .remove_event_listener_with_callback("dragover", &on_dragover)
+                        .unwrap();
+                }
+
+                let id = id.clone();
+                request_animation_frame(move || {
+                    let mut current = currently_dragged_panel.write();
+                    if current.as_deref() == Some(&id) {
+                        hover_info.set(None);
+                        draggable.set(false);
+                        *current = None;
+                    }
+                });
+            }
+        };
+
+        PanelReorderEvents {
+            node_ref,
+            is_dragging,
+            hover_position,
+            draggable: draggable.into(),
+            set_draggable,
+            on_dragstart: on_drag_start,
+            on_dragend: on_drag_end,
+        }
+    }
+
+    /// Registers a panel with drag reordering for a given ID.
+    pub fn generate_header(
+        &self,
+        index: usize,
+    ) -> (NodeRef<Div>, Signal<Option<HoverPosition>>) {
+        if !self.initialized.get_untracked() {
+            self.initialize();
+        }
+        let node_ref = NodeRef::<Div>::new();
+
+        let hover_position = Signal::derive({
+            let hover_info = self.hover_info.clone();
+            move || match &*hover_info.read() {
+                Some(HoverInfo {
+                    panel: None,
+                    column_index
+                }) => if *column_index == index {
+                    Some(HoverPosition::After)
+                } else {
+                    None
+                }
+                _ => None
+            }
+        });
+        (node_ref, hover_position)
+    }
+}
+
+/// Return value for [`use_drag_reorder`].
+pub struct PanelReorderEvents<SetDraggable, OnDragStart, OnDragEnd>
+where
+    SetDraggable: Fn(bool) + Copy,
+    OnDragStart: Fn(ev::DragEvent) + Clone,
+    OnDragEnd: Fn(ev::DragEvent) + Clone,
+{
+    /// Node ref which should be assigned to the panel element.
+    pub node_ref: NodeRef<Div>,
+    /// Is this panel being dragged.
+    pub is_dragging: Signal<bool>,
+    /// The current position this panel is being hovered over.
+    ///
+    /// This is useful for styling. Typically you would have a line above or below this panel to indicate
+    /// the dragged panel can be dropped.
+    pub hover_position: Signal<Option<HoverPosition>>,
+    /// Is the panel draggable.
+    pub draggable: Signal<bool>,
+    /// Enables/disables the panel to be draggable.
+    pub set_draggable: SetDraggable,
+    /// Callback which should be assigned to the `on:dragstart` event.
+    pub on_dragstart: OnDragStart,
+    /// Callback which should be assigned to the `on:dragend` event.
+    pub on_dragend: OnDragEnd,
+}
+
+/// A hovering panels position either above or below.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HoverPosition {
+    Before,
+    After,
+}


### PR DESCRIPTION
My preference is to get this incorporated into Thaw (see https://github.com/thaw-ui/thaw/pull/321), but if you want to keep this stand-alone, here's the update and an updated example.